### PR TITLE
Remove specific font family validation

### DIFF
--- a/HTMLToQPDF/Components/ParagraphComponent.cs
+++ b/HTMLToQPDF/Components/ParagraphComponent.cs
@@ -127,7 +127,7 @@ namespace HTMLQuestPDF.Components
         {
             foreach (var attr in element.Attributes)
             {
-                if(attr.Name == "style")
+                if (attr.Name == "style")
                 {
                     style = ParseStyleString(attr.Value, style);
                 }
@@ -154,8 +154,8 @@ namespace HTMLQuestPDF.Components
                             }
                             break;
                         case "font-family":
-                            string font = FontFamilyUtils.formatFontFamily(styleValue);
-                            if (FontFamilyUtils.isFontFamilyValid(font))
+                            string font = FontFamilyUtils.FormatFontFamily(styleValue);
+                            if (FontFamilyUtils.IsFontFamilyValid(font))
                             {
                                 textStyle = textStyle.FontFamily(font);
                             }

--- a/HTMLToQPDF/Components/ParagraphComponent.cs
+++ b/HTMLToQPDF/Components/ParagraphComponent.cs
@@ -155,7 +155,7 @@ namespace HTMLQuestPDF.Components
                             break;
                         case "font-family":
                             string font = FontFamilyUtils.FormatFontFamily(styleValue);
-                            if (FontFamilyUtils.IsFontFamilyValid(font))
+                            if (!string.IsNullOrEmpty(font))
                             {
                                 textStyle = textStyle.FontFamily(font);
                             }

--- a/HTMLToQPDF/Utils/FontFamilyUtils.cs
+++ b/HTMLToQPDF/Utils/FontFamilyUtils.cs
@@ -5,21 +5,6 @@ namespace HTMLToQPDF.Utils
 {
     internal static class FontFamilyUtils
     {
-        private static readonly HashSet<string> availableFonts = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            "Arial",
-            "Brush Script MT",
-            "Courier New",
-            "Garamond",
-            "Montserrat",
-            "Helvetica",
-            "Tahoma",
-            "Trebuchet MS",
-            "Times New Roman",
-            "Verdana",
-            "Georgia"
-        };
-
         public static string FormatFontFamily(string fontFamily)
         {
             var font = fontFamily;
@@ -32,11 +17,6 @@ namespace HTMLToQPDF.Utils
             font = font.Replace("\"", string.Empty);
 
             return font;
-        }
-
-        public static bool IsFontFamilyValid(string fontFamily)
-        {
-            return availableFonts.Contains(fontFamily);
         }
     }
 }

--- a/HTMLToQPDF/Utils/FontFamilyUtils.cs
+++ b/HTMLToQPDF/Utils/FontFamilyUtils.cs
@@ -20,7 +20,7 @@ namespace HTMLToQPDF.Utils
             "Georgia"
         };
 
-        public static string formatFontFamily(string fontFamily)
+        public static string FormatFontFamily(string fontFamily)
         {
             var font = fontFamily;
             int comma = font.IndexOf(',');
@@ -34,7 +34,7 @@ namespace HTMLToQPDF.Utils
             return font;
         }
 
-        public static bool isFontFamilyValid(string fontFamily)
+        public static bool IsFontFamilyValid(string fontFamily)
         {
             return availableFonts.Contains(fontFamily);
         }


### PR DESCRIPTION
Replaced the unnecessary font "validation" check for a `IsNullOrEmpty` check. Also, updated a couple utility methods to follow C# name capitalization conventions.