### PR TITLE
Trim end of last node in lineNodes instead of first

### DIFF
--- a/HTMLToQPDF/Components/ParagraphComponent.cs
+++ b/HTMLToQPDF/Components/ParagraphComponent.cs
@@ -48,7 +48,7 @@ namespace HTMLQuestPDF.Components
             }
 
             var first = lineNodes.First();
-            var last = lineNodes.First();
+            var last = lineNodes.Last();
 
             first.InnerHtml = first.InnerHtml.TrimStart();
             last.InnerHtml = last.InnerHtml.TrimEnd();


### PR DESCRIPTION
In `ParagraphComponent.cs`, updated the assignment of the `last` variable to use `lineNodes.Last()` instead of `lineNodes.First()`, so that whitespace is trimmed from the actual last node, not the first one twice.